### PR TITLE
K smallest elements

### DIFF
--- a/FastPriorityQueue.js
+++ b/FastPriorityQueue.js
@@ -232,6 +232,30 @@ FastPriorityQueue.prototype.forEach = function(callback) {
   }
 };
 
+// return the k smallest elements of the queue
+// runs in O(k log k) time
+FastPriorityQueue.prototype.kSmallest = function(k) {
+  var fpq = new FastPriorityQueue(function(a,b){ return a.data < b.data; });
+  k = Math.min(this.size, k);
+  var smallest = new Array(k);
+  var i = 0;
+  var j = 0;
+  var l = 0;
+  var r = 0;
+  var ai = this.array[i];
+  fpq.add({data: ai, idx: i});
+  while (j < k) {
+    var small = fpq.poll();
+    smallest[j++] = small.data;
+    i = small.idx;
+    l = (i << 1) + 1;
+    r = l + 1;
+    if (this.array[l]) fpq.add({data: this.array[l], idx: l});
+    if (this.array[r]) fpq.add({data: this.array[r], idx: r});
+  }
+  return smallest;
+}
+
 // just for illustration purposes
 var main = function() {
   // main code

--- a/FastPriorityQueue.js
+++ b/FastPriorityQueue.js
@@ -235,7 +235,8 @@ FastPriorityQueue.prototype.forEach = function(callback) {
 // return the k smallest elements of the queue
 // runs in O(k log k) time
 FastPriorityQueue.prototype.kSmallest = function(k) {
-  var fpq = new FastPriorityQueue(function(a,b){ return a.data < b.data; });
+  var comparator = this.compare;
+  var fpq = new FastPriorityQueue(function(a,b){ return comparator(a.data,b.data); });
   k = Math.min(this.size, k);
   var smallest = new Array(k);
   var i = 0;

--- a/FastPriorityQueue.js
+++ b/FastPriorityQueue.js
@@ -245,7 +245,7 @@ FastPriorityQueue.prototype.kSmallest = function(k) {
   var r = 0;
   var ai = this.array[i];
   fpq.add({data: ai, idx: i});
-  while (j < k) {
+  while (j < k && fpq.size > 0) {
     var small = fpq.poll();
     smallest[j++] = small.data;
     i = small.idx;

--- a/unit/basictests.js
+++ b/unit/basictests.js
@@ -169,4 +169,37 @@ describe('FastPriorityQueue', function() {
       }
     }
   });
+
+  it('should return k smallest', function() {
+    // ascending
+    var x = new FastPriorityQueue(function(a, b) {
+      return a < b;
+    });
+    x.add(1);
+    x.add(0);
+    x.add(5);
+    x.add(4);
+    x.add(3);
+    x.add(7);
+    x.add(4.5);
+    x.add(12);
+    x.add(3.223);
+    x.add(1.2);
+    x.add(2.22);
+    x.add(0.003);
+
+    var iterOrder = [0, 0.003, 1, 1.2, 2.22, 3, 3.223, 4, 4.5, 5, 7, 12];
+
+    // first iterate without mutating the queue
+    checkOrderNonVolatile(x, iterOrder);
+
+    // check k smallest for k = 0 ... n
+    for (var i = 0; i < x.size; i++) if (JSON.stringify(x.kSmallest(i)) !== JSON.stringify(iterOrder.slice(0,i))) throw 'bug';
+
+    // then iterate via polling
+    for (var i = 0; i < iterOrder.length; i++) {
+      var item = iterOrder[i];
+      if (x.poll() != item) throw 'bug';
+    }
+  });
 });


### PR DESCRIPTION
To find the k smallest elements we:

1) Create a new PQ, fpq. 
2) Add the root to fpq.
3) Poll the fpq.
4) Add the two children of the polled element to the fpq.
5) Repeat step 3-4 k times

Total complexity: O (k log k). Just polling the entire queue k times and adding each element back is O (k log n). So if k is much smaller than n this provides a significant speedup.

Process is described in detail here: https://stackoverflow.com/questions/7650917/oklogk-time-algorithm-to-find-kth-smallest-element-from-a-binary-heap