### PR TITLE
Remove, removeOne, removeMany, & type definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+.vscode

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+node_modules
+unit
+benchmark
+.vscode
+
+.travis.yml

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,3 +6,5 @@
 * [Rui Araújo](https://github.com/ruiaraujo)
 * [Zach Auclair](https://github.com/blaskovicz)
 * [Kaisle](https://github.com/Kaisle)
+* [Moshe Shababo](https://github.com/moshababo)
+* [Daniel McNally](https://github.com/sangaman)

--- a/FastPriorityQueue.d.ts
+++ b/FastPriorityQueue.d.ts
@@ -1,0 +1,35 @@
+declare class FastPriorityQueue<T> {
+  /** The provided comparator function should take a, b and return *true* when a < b. */
+  constructor(comparator: (a: T, b: T) => boolean);
+  /** Add an element into the queue. Runs in O(log n) time. */
+  add: (value: T) => void;
+  /** Copy the priority queue into another, and return it. Queue items are shallow-copied. Runs in `O(n)` time. */
+  clone: () => FastPriorityQueue<T>;
+  /** Iterate over the items in order. */
+  forEach: (callback: (value: T, index: number) => void) => void;
+  /** Replace the content of the heap by provided array and "heapify it." */
+  heapify: (array: T[]) => void;
+  /** Check whether the heap is empty. */
+  isEmpty: () => boolean;
+  /** Look at the top of the queue (the smallest element) without removing it. Executes in constant time. */
+  peek: () => T | undefined;
+  /** Remove the element on top of the heap (the smallest element). Runs in logarithmic time */
+  poll: () => T | undefined;
+  /** Remove an element matching the provided value from the queue, checked for equality by using the queue's comparator. Return true if removed, false otherwise. */
+  remove: (value: T) => boolean;
+  /** Remove the first item for which the callback will return true. Return the removed item, or undefined if nothing is removed. */
+  removeMany: (callback: (a: T) => boolean, limit?: number) => T[];
+  /** 
+   * Remove each item for which the callback returns true, up to a max limit of removed items if specified or no limit if unspecified.
+   * Return an array containing the removed items.
+   */
+  removeOne: (callback: (a: T) => boolean) => T | undefined;
+  /** Add the provided value to the heap while removing and returning the smallest value. The size of the queue thus remains unchanged. */
+  replaceTop: (value: T) => T | undefined;
+  /** The number of elements in the queue. */
+  size: number;
+  /** Recover unused memory (for long-running priority queues). */
+  trim: () => void;
+  }
+
+  export default FastPriorityQueue;

--- a/FastPriorityQueue.js
+++ b/FastPriorityQueue.js
@@ -138,21 +138,19 @@ FastPriorityQueue.prototype._removeAt = function(index) {
   return true;
 };
 
-// remove(myval[, comparator]) will remove the given item from the
-// queue, checked for equality by using compare if a new comparator isn't provided.
-// (for exmaple, if you want to remove based on a seperate key value, not necessarily priority).
+// remove(callback) will execute the callback function for each
+// item of the queue and will remove the item if the callback will return true.
 // return true if removed.
-FastPriorityQueue.prototype.remove = function(myval, comparator) {
-  if (!comparator) {
-    comparator = this.compare;
+FastPriorityQueue.prototype.remove = function(callback) {
+  if (!callback) {
+    return false;
   }
   if (this.isEmpty()) return false;
   for (var i = 0; i < this.size; i++) {
-    if (comparator(this.array[i], myval) || comparator(myval, this.array[i])) {
-      continue;
+    if (callback(this.array[i])) {
+      // items are equal, remove
+      return this._removeAt(i);
     }
-    // items are equal, remove
-    return this._removeAt(i);
   }
   return false;
 };

--- a/FastPriorityQueue.js
+++ b/FastPriorityQueue.js
@@ -39,6 +39,8 @@ function FastPriorityQueue(comparator) {
   this.compare = comparator || defaultcomparator;
 }
 
+// copy the priority queue into another, and return it. Queue items are shallow-copied.
+// Runs in `O(n)` time.
 FastPriorityQueue.prototype.clone = function() {
   var fpq = new FastPriorityQueue(this.compare);
   fpq.size = this.size;
@@ -68,7 +70,7 @@ FastPriorityQueue.prototype.add = function(myval) {
   this.array[i] = myval;
 };
 
-// replace the content of the heap by provided array and "heapifies it"
+// replace the content of the heap by provided array and "heapify it"
 FastPriorityQueue.prototype.heapify = function(arr) {
   this.array = arr;
   this.size = arr.length;
@@ -124,38 +126,74 @@ FastPriorityQueue.prototype._percolateDown = function(i) {
 };
 
 // internal
-// _removeAt(index) will delete the given index from the queue,
-// retaining balance. returns true if removed.
+// _removeAt(index) will remove the item at the given index from the queue,
+// retaining balance. returns the removed item, or undefined if nothing is removed.
 FastPriorityQueue.prototype._removeAt = function(index) {
-  if (this.isEmpty() || index > this.size - 1 || index < 0) return false;
+  if (index > this.size - 1 || index < 0) return undefined;
 
   // impl1:
   //this.array.splice(index, 1);
   //this.heapify(this.array);
   // impl2:
   this._percolateUp(index, true);
-  this.poll();
-  return true;
+  return this.poll();
 };
 
-// remove(callback) will execute the callback function for each
-// item of the queue and will remove the item if the callback will return true.
-// return true if removed.
-FastPriorityQueue.prototype.remove = function(callback) {
-  if (!callback) {
-    return false;
-  }
-  if (this.isEmpty()) return false;
+// remove(myval) will remove an item matching the provided value from the
+// queue, checked for equality by using the queue's comparator.
+// return true if removed, false otherwise.
+FastPriorityQueue.prototype.remove = function(myval) {
   for (var i = 0; i < this.size; i++) {
-    if (callback(this.array[i])) {
-      // items are equal, remove
-      return this._removeAt(i);
+    if (!this.compare(this.array[i], myval) && !this.compare(myval, this.array[i])) {
+      // items match, comparator returns false both ways, remove item
+      this._removeAt(i);
+      return true;
     }
   }
   return false;
 };
 
-// Look at the top of the queue (a smallest element)
+// internal
+// removes and returns items for which the callback returns true.
+FastPriorityQueue.prototype._batchRemove = function(callback, limit) {
+  // initialize return array with max size of the limit or current queue size
+  var retArr = new Array(limit ? limit : this.size);
+  var count = 0;
+
+  if (typeof callback === 'function' && this.size) {
+    var i = 0;
+    while (i < this.size && count < retArr.length) {
+      if (callback(this.array[i])) {
+        retArr[count] = this._removeAt(i);
+        count++;
+        // move up a level in the heap if we remove an item
+        i = i >> 1;
+      } else {
+        i++;
+      }
+    } 
+  }
+  retArr.length = count;
+  return retArr;
+}
+
+// removeOne(callback) will execute the callback function for each item of the queue
+// and will remove the first item for which the callback will return true.
+// return the removed item, or undefined if nothing is removed.
+FastPriorityQueue.prototype.removeOne = function(callback) {
+  var arr = this._batchRemove(callback, 1);
+  return arr.length > 0 ? arr[0] : undefined;
+};
+
+// remove(callback[, limit]) will execute the callback function for each item of
+// the queue and will remove each item for which the callback returns true, up to
+// a max limit of removed items if specified or no limit if unspecified.
+// return an array containing the removed items.
+FastPriorityQueue.prototype.removeMany = function(callback, limit) {
+  return this._batchRemove(callback, limit);
+};
+
+// Look at the top of the queue (one of the smallest elements) without removing it
 // executes in constant time
 //
 // Calling peek on an empty priority queue returns
@@ -167,7 +205,7 @@ FastPriorityQueue.prototype.peek = function() {
   return this.array[0];
 };
 
-// remove the element on top of the heap (a smallest element)
+// remove the element on top of the heap (one of the smallest elements)
 // runs in logarithmic time
 //
 // If the priority queue is empty, the function returns the
@@ -182,7 +220,7 @@ FastPriorityQueue.prototype.poll = function() {
   var ans = this.array[0];
   if (this.size > 1) {
     this.array[0] = this.array[--this.size];
-    this._percolateDown(0 | 0);
+    this._percolateDown(0);
   } else {
     this.size -= 1;
   }
@@ -190,13 +228,13 @@ FastPriorityQueue.prototype.poll = function() {
 };
 
 // This function adds the provided value to the heap, while removing
-//  and returning the peek value (like poll). The size of the priority
+// and returning one of the smallest elements (like poll). The size of the queue
 // thus remains unchanged.
 FastPriorityQueue.prototype.replaceTop = function(myval) {
   if (this.size == 0) return undefined;
   var ans = this.array[0];
   this.array[0] = myval;
-  this._percolateDown(0 | 0);
+  this._percolateDown(0);
   return ans;
 };
 

--- a/README.md
+++ b/README.md
@@ -62,13 +62,15 @@ Instance methods summary:
 
 * `add(value)`: add an element into the queue; runs in `O(log n)` time.
 * `poll()`: remove and return the element on top of the heap (smallest element); runs in `O(log n)` time. If the priority queue is empty, the function returns `undefined`.
-* `remove(value[, comparator])`: remove the given item, if found, from the queue. The item is found by using the queue's comparator (if a new comparator function isn't provided). A custom comparator is useful if you want to remove based on a seperate key value, not necessarily priority. Returns `true` if an item is removed, `false` otherwise.
-* `replaceTop(value)`: `poll()` and `add(value)` in one operation. This is useful for [fast, top-k queries](http://lemire.me/blog/2017/06/21/top-speed-for-top-k-queries/). Returns the removed element, similar to `poll()`.
+* `remove(value)`: remove an element matching the provided value, if found, from the queue. The item is matched by using the queue's comparator. Returns `true` if the element is removed, `false` otherwise.
+* `removeOne(callback)`: execute the callback function for each item of the queue and remove the first item for which the callback will return true. Returns the removed item, or `undefined` if nothing is removed.
+* `removeMany(callback[, limit])`: execute the callback function for each item of the queue and remove each item for which the callback will return true, up to a max limit of removed items if specified or no limit if unspecified. Returns an array containing the removed items.
+* `replaceTop(value)`: `poll()` and `add(value)` in one operation. This is useful for [fast, top-k queries](http://lemire.me/blog/2017/06/21/top-speed-for-top-k-queries/). Returns the removed element or `undefined`, similar to `poll()`.
 * `heapify(array)`: replace the content of the heap with the provided array, then order it based on the comparator.
-* `peek()`: return the top of the queue (smallest element) without removal; runs in `O(1)` time.
+* `peek()`: return the top of the queue (smallest element) without removal, or `undefined` if the queue is empty; runs in `O(1)` time.
 * `isEmpty()`: return `true` if the the queue has no elements, false otherwise.
 * `clone()`: copy the priority queue into another, and return it. Queue items are shallow-copied. Runs in `O(n)` time.
-* `forEach(callback)`: iterate over all items in the priority queue from smallest to largest. `callback` should be a function that accepts two arguements, `value` (the item), and `index`, the zero-based index of the item.
+* `forEach(callback)`: iterate over all items in the priority queue from smallest to largest. `callback` should be a function that accepts two arguments, `value` (the item), and `index`, the zero-based index of the item.
 * `trim()`: clean up unused memory in the heap; useful after high-churn operations like many `add()`s then `remove()`s.
 
 # npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fastpriorityqueue",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "priority queue",
     "performance"
   ],
-  "version": "0.5.0",
+  "version": "0.6.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lemire/FastPriorityQueue.js.git"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "url": "git+https://github.com/lemire/FastPriorityQueue.js.git"
   },
   "main": "FastPriorityQueue.js",
+  "types": "FastPriorityQueue.d.ts",
   "scripts": {
     "test": "mocha unit/basictests.js"
   },

--- a/unit/basictests.js
+++ b/unit/basictests.js
@@ -77,8 +77,15 @@ describe('FastPriorityQueue', function() {
 
   it('remove', function() {
     var x = new FastPriorityQueue();
+
+    // should return false when queue is empty
+    if(x.remove(0) !== false) throw 'bug';
+
     x.heapify([8, 6, 7, 5, 3, 0, 9, 1, 0]);
     checkOrderNonVolatile(x, [0, 0, 1, 3, 5, 6, 7, 8, 9]);
+
+    // should return false when no matching element is in the queue
+    if(x.remove(10) !== false) throw 'bug';
 
     if (!x.remove(0)) throw 'bug';
     checkOrderNonVolatile(x, [0, 1, 3, 5, 6, 7, 8, 9]);
@@ -98,6 +105,52 @@ describe('FastPriorityQueue', function() {
 
     if (x.remove(1)) throw 'bug';
     checkOrderNonVolatile(x, [0, 5, 8]);
+  });
+
+  it('removeOne', function() {
+    var x = new FastPriorityQueue();
+    
+    var callback = function(val) {
+      return val === 1;
+    }
+
+    var removedItem = x.removeOne(callback);
+    if (removedItem !== undefined) throw 'bug';
+
+    x.heapify([8, 6, 7, 5, 3, 0, 9, 1, 0]);
+
+    removedItem = x.removeOne(callback);
+    if (removedItem !== 1) throw 'bug';
+    checkOrderNonVolatile(x, [0, 0, 3, 5, 6, 7, 8, 9]);
+
+    removedItem = x.removeOne(callback);
+    if (removedItem !== undefined) throw 'bug';
+    checkOrderNonVolatile(x, [0, 0, 3, 5, 6, 7, 8, 9]);
+  });  
+
+  it('removeMany', function() {
+    var x = new FastPriorityQueue();
+    x.heapify([8, 9, 9, 2, 1, 0, 4, 6, 2, 7, 6, 8, 7, 8, 0, 6, 7, 1, 6, 1, 7, 8, 3, 8, 4, 1, 2, 9, 6, 1, 8, 7, 2, 7, 7, 8, 8, 5, 8, 8]);
+
+    var callback = function(val) {
+      return val === 6;
+    }
+    var removedItems = x.removeMany(callback);
+    if (removedItems.length !== 5 || x.size !== 35) throw 'bug';
+    checkOrderNonVolatile(x, [0,0,1,1,1,1,1,2,2,2,2,3,4,4,5,7,7,7,7,7,7,7,8,8,8,8,8,8,8,8,8,8,9,9,9]);
+
+    callback = function(val) {
+      return val > 6;
+    }
+    removedItems = x.removeMany(callback);
+    if (removedItems.length !== 20 || x.size !== 15) throw 'bug';
+    checkOrderNonVolatile(x, [0,0,1,1,1,1,1,2,2,2,2,3,4,4,5]);
+
+    callback = function(val) {
+      return true;
+    }
+    removedItems = x.removeMany(callback, 10);
+    if (removedItems.length !== 10 || x.size !== 5) throw 'bug';
   });
 
   it('Random', function() {

--- a/unit/basictests.js
+++ b/unit/basictests.js
@@ -153,6 +153,37 @@ describe('FastPriorityQueue', function() {
     if (removedItems.length !== 10 || x.size !== 5) throw 'bug';
   });
 
+  it('removeMany remove all - one item', function() {
+    var x = new FastPriorityQueue();
+    x.heapify([1]);
+
+    var callback = function (val) {
+      return true;
+    }
+
+    var removedItems = x.removeMany(callback);
+    if (removedItems.length !== 1 || x.size !== 0) throw 'bug';
+  });
+
+  it('removeMany remove all - more than one item', function() {
+    var x = new FastPriorityQueue();
+    x.heapify([1,2]);
+
+    var callback = function (val) {
+      return true;
+    }
+
+    var removedItems = x.removeMany(callback);
+    if (removedItems.length !== 2 || x.size !== 0) {
+      console.log('removed: ' + JSON.stringify(removedItems));
+      console.log('remaining:');
+      while (!x.isEmpty()) {
+        console.log(x.poll());
+      }
+      throw 'bug';
+    }
+  });
+
   it('Random', function() {
     for (var ti = 0; ti < 100; ti++) {
       var b = new FastPriorityQueue(function(a, b) {


### PR DESCRIPTION
We created a fork of this repo to implement some needed removal functionality. I thought I'd see about getting these changes merged in here. I've cleaned up the commit history for this PR. Changes include:

- Making `remove` a "remove by value" method which uses the comparator defined for the queue to look for an item in the queue matching the provided element. It no longer accepts a different comparator (that functionality is implemented in new methods) but it passes pre-existing tests.
- Adding `removeOne` and `removeMany` methods which take a callback and remove items that return true when passed to the callback. Also new tests for these methods.
- Adding type definitions for use in TypeScript projects.
- Various fixes or enhancements to comments and the README.
- Bumping the minor version to 0.6.0 to indicate new features.