### PR TITLE
Use proper typescript export

### DIFF
--- a/FastPriorityQueue.d.ts
+++ b/FastPriorityQueue.d.ts
@@ -34,4 +34,4 @@ declare class FastPriorityQueue<T> {
   kSmallest: (k: number) => T[];
 }
 
-export default FastPriorityQueue;
+export = FastPriorityQueue;


### PR DESCRIPTION
Source JavaScript replaces `module.exports` with `FastPriorityQueue` class:
https://github.com/lemire/FastPriorityQueue.js/blob/7eb318295e589a75f7372e133886bba52bd784bc/FastPriorityQueue.js#L318

However in TypeScript definition file class is exported with _default_ export:
https://github.com/lemire/FastPriorityQueue.js/blob/7eb318295e589a75f7372e133886bba52bd784bc/FastPriorityQueue.d.ts#L35


These are not compatible when used in TypeScript projects hence `export =` should be used instead.
https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require
