### PR TITLE
Remove lines that cause issues with iife / umd bundling

### DIFF
--- a/FastPriorityQueue.js
+++ b/FastPriorityQueue.js
@@ -295,24 +295,4 @@ FastPriorityQueue.prototype.kSmallest = function(k) {
   return smallest;
 }
 
-// just for illustration purposes
-var main = function() {
-  // main code
-  var x = new FastPriorityQueue(function(a, b) {
-    return a < b;
-  });
-  x.add(1);
-  x.add(0);
-  x.add(5);
-  x.add(4);
-  x.add(3);
-  while (!x.isEmpty()) {
-    console.log(x.poll());
-  }
-};
-
-if (require.main === module) {
-  main();
-}
-
 module.exports = FastPriorityQueue;


### PR DESCRIPTION
The hardcode of looking at properties of require isn't handled well by bundlers that are targeting something besides cjs. They don't seem like they really serve a purpose, and removing them may help other projects that use this library but then bundle it.

I'm totally okay with rejecting this change, or deciding on a different route, but there seem to be plenty of ways to illustrate the library in action, and one that breaks a potential use case may not be the best one.