### PR TITLE
Update benchmark results with more recent version of Node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,33 +97,37 @@ In some tests, it can be five times faster than any other
 JavaScript implementation we could find.
 
 ```
-$ node test.js
-Platform: linux 4.4.0-38-generic x64
-Intel(R) Core(TM) i7-6700 CPU @ 3.40GHz
-Node version 4.5.0, v8 version 4.5.103.37
+$ node benchmark/test.js
+Platform: darwin 20.1.0 x64
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+Node version 14.7.0, v8 version 8.4.371.19-node.12
 
 Comparing against:
 js-priority-queue: https://github.com/adamhooper/js-priority-queue 0.1.5
+stablepriorityqueue: https://github.com/lemire/StablePriorityQueue.js 0.1.2
 heap.js: https://github.com/qiao/heap.js 0.2.6
 binaryheapx: https://github.com/xudafeng/BinaryHeap 0.1.1
 priority_queue: https://github.com/agnat/js_priority_queue 0.1.3
 js-heap: https://github.com/thauburger/js-heap 0.3.1
 queue-priority: https://github.com/augustohp/Priority-Queue-NodeJS 1.0.0
-priorityqueuejs: https://github.com/janogonzalez/priorityqueuejs 1.0.0
-qheap: https://github.com/andrasq/node-qheap 1.3.0
+priorityqueuejs: https://github.com/janogonzalez/priorityqueuejs 2.0.0
+qheap: https://github.com/andrasq/node-qheap 1.4.0
 yabh: https://github.com/jmdobry/yabh 1.2.0
 
 starting dynamic queue/enqueue benchmark
-FastPriorityQueue x 36,813 ops/sec ±0.15% (98 runs sampled)
-js-priority-queue x 5,374 ops/sec ±0.29% (97 runs sampled)
-heap.js x 7,525 ops/sec ±0.21% (94 runs sampled)
-binaryheapx x 4,741 ops/sec ±0.19% (98 runs sampled)
-priority_queue x 3,657 ops/sec ±2.37% (92 runs sampled)
-js-heap x 271 ops/sec ±0.35% (90 runs sampled)
-queue-priority x 455 ops/sec ±0.44% (90 runs sampled)
-priorityqueuejs x 7,012 ops/sec ±0.14% (75 runs sampled)
-qheap x 36,289 ops/sec ±0.33% (97 runs sampled)
-yabh x 3,975 ops/sec ±3.57% (76 runs sampled)
+FastPriorityQueue x 36,816 ops/sec ±0.74% (92 runs sampled)
+FastPriorityQueue---replaceTop x 107,942 ops/sec ±0.71% (91 runs sampled)
+sort x 6,240 ops/sec ±1.65% (92 runs sampled)
+StablePriorityQueue x 10,333 ops/sec ±4.09% (91 runs sampled)
+js-priority-queue x 14,435 ops/sec ±1.97% (91 runs sampled)
+heap.js x 6,568 ops/sec ±2.29% (90 runs sampled)
+binaryheapx x 8,595 ops/sec ±0.56% (94 runs sampled)
+priority_queue x 8,201 ops/sec ±0.74% (94 runs sampled)
+js-heap x 557 ops/sec ±1.70% (89 runs sampled)
+queue-priority x 291 ops/sec ±2.46% (88 runs sampled)
+priorityqueuejs x 13,864 ops/sec ±2.02% (90 runs sampled)
+qheap x 26,882 ops/sec ±1.81% (93 runs sampled)
+yabh x 10,472 ops/sec ±1.50% (93 runs sampled)
 Fastest is FastPriorityQueue
 ```
 


### PR DESCRIPTION
I re-ran the benchmark script out of curiosity. I'm surprised the results aren't a bigger improvement given 5 years of V8 updates since `4.5` and this CPU is 3 years newer.

![image](https://user-images.githubusercontent.com/709451/105622885-f5e27200-5dc9-11eb-9f68-a9a73acb0c8c.png)
