### PR TITLE
Improve kSmallest and clone performance

### DIFF
--- a/FastPriorityQueue.js
+++ b/FastPriorityQueue.js
@@ -44,9 +44,7 @@ function FastPriorityQueue(comparator) {
 FastPriorityQueue.prototype.clone = function() {
   var fpq = new FastPriorityQueue(this.compare);
   fpq.size = this.size;
-  for (var i = 0; i < this.size; i++) {
-    fpq.array.push(this.array[i]);
-  }
+  fpq.array = this.array.slice(0, this.size);
   return fpq;
 };
 
@@ -273,22 +271,15 @@ FastPriorityQueue.prototype.forEach = function(callback) {
 // from the priority queue.
 FastPriorityQueue.prototype.kSmallest = function(k) {
   if (this.size == 0) return [];
-  var comparator = this.compare;
-  var arr = this.array
-  var fpq = new FastPriorityQueue(function(a,b){
-   return comparator(arr[a],arr[b]);
-  });
   k = Math.min(this.size, k);
+  var fpq = new FastPriorityQueue(this.compare);
+  const newSize = Math.min((k > 0 ? Math.pow(2, k - 1) : 0) + 1, this.size);
+  fpq.size = newSize;
+  fpq.array = this.array.slice(0, newSize);
+
   var smallest = new Array(k);
-  var j = 0;
-  fpq.add(0);
-  while (j < k) {
-    var small = fpq.poll();
-    smallest[j++] = this.array[small];
-    var l = (small << 1) + 1;
-    var r = l + 1;
-    if (l < this.size) fpq.add(l);
-    if (r < this.size) fpq.add(r);
+  for (var i = 0; i < k; i++) {
+    smallest[i] = fpq.poll();
   }
   return smallest;
 }

--- a/benchmark/test.js
+++ b/benchmark/test.js
@@ -91,6 +91,16 @@ function QueueEnqueueBench(blocks) {
       }
       return b;
     })
+    .add('FastPriorityQueue--queue-and-kSmallest', function() {
+      var b = new FastPriorityQueue(defaultcomparator);
+      for (var i = 0 ; i < 1280  ; i++) {
+        b.add(rand(i));
+      }
+      for (i = 128 ; i < 128 * blocks  ; i++) {
+        b.kSmallest(i % 1300)
+      }
+      return b;
+    })
      .add('sort', function() {
       var a = new Array();
       for (var i = 0 ; i < 128 * (blocks + 1)  ; i++) {


### PR DESCRIPTION
I was trying to improve performance of [JITDB](https://github.com/ssb-ngi-pointer/jitdb), and I noticed some calls to this library that could be improved.

The `kSmallest` method seemed to be running unusually slowly compared with other methods in this library. While the overall algorithm looked sound, it didn't seem to stand up to empirical testing & I found more success by simply cloning the inner array and dequeuing elements from it. I calculated an upper bound on how many elements to clone based on how deep `kSmallest` may need to look in the heap for results.

I updated `clone` while I was at it. The change from `push` to `slice` should take better advantage of JS engine optimizations for the initial copy, though I can't speak to whether the resulting array will be considered "packed" or "holey".