### PR TITLE
Optimize baseline and special case performance for kSmallest

### DIFF
--- a/FastPriorityQueue.js
+++ b/FastPriorityQueue.js
@@ -287,13 +287,22 @@ FastPriorityQueue.prototype.forEach = function(callback) {
 FastPriorityQueue.prototype.kSmallest = function(k) {
   if (this.size == 0) return [];
   k = Math.min(this.size, k);
-  var fpq = new FastPriorityQueue(this.compare);
-  const newSize = Math.min((k > 0 ? Math.pow(2, k - 1) : 0) + 1, this.size);
+  const newSize = Math.min(this.size, (1 << (k - 1)) + 1);
+  if (newSize < 2) {
+    if (newSize < 1)  {
+      return [];
+    } else if (k > 0) {
+      return [this.peek()];
+    }
+  }
+  if (k < 1) return [];
+
+  const fpq = new FastPriorityQueue(this.compare);
   fpq.size = newSize;
   fpq.array = this.array.slice(0, newSize);
 
-  var smallest = new Array(k);
-  for (var i = 0; i < k; i++) {
+  const smallest = new Array(k);
+  for (let i = 0; i < k; i++) {
     smallest[i] = fpq.poll();
   }
   return smallest;

--- a/FastPriorityQueue.js
+++ b/FastPriorityQueue.js
@@ -285,17 +285,10 @@ FastPriorityQueue.prototype.forEach = function(callback) {
 // runs in O(k log k) time, the elements are not removed
 // from the priority queue.
 FastPriorityQueue.prototype.kSmallest = function(k) {
-  if (this.size == 0) return [];
+  if ((this.size == 0) || (k<=0)) return [];
   k = Math.min(this.size, k);
   const newSize = Math.min(this.size, (1 << (k - 1)) + 1);
-  if (newSize < 2) {
-    if (newSize < 1)  {
-      return [];
-    } else if (k > 0) {
-      return [this.peek()];
-    }
-  }
-  if (k < 1) return [];
+  if (newSize < 2) { return [this.peek()] }
 
   const fpq = new FastPriorityQueue(this.compare);
   fpq.size = newSize;


### PR DESCRIPTION
Improve the baseline and special case performance of `kSmallest`.

Before:

```
starting dynamic queue/enqueue benchmark
FastPriorityQueue--queue-and-kSmallest x 26.71 ops/sec ±1.26% (48 runs sampled)

starting dynamic queue/enqueue benchmark
FastPriorityQueue--queue-and-kSmallest x 2.75 ops/sec ±1.76% (11 runs sampled)
```

After:

```
starting dynamic queue/enqueue benchmark
FastPriorityQueue--queue-and-kSmallest x 36.96 ops/sec ±1.03% (64 runs sampled)

starting dynamic queue/enqueue benchmark
FastPriorityQueue--queue-and-kSmallest x 3.66 ops/sec ±1.26% (14 runs sampled)
```