### PR TITLE
Fix kSmallest exponent bug

### DIFF
--- a/FastPriorityQueue.js
+++ b/FastPriorityQueue.js
@@ -287,7 +287,7 @@ FastPriorityQueue.prototype.forEach = function(callback) {
 FastPriorityQueue.prototype.kSmallest = function(k) {
   if ((this.size == 0) || (k<=0)) return [];
   k = Math.min(this.size, k);
-  const newSize = Math.min(this.size, (1 << (k - 1)) + 1);
+  const newSize = Math.min(this.size, (2 ** (k - 1)) + 1);
   if (newSize < 2) { return [this.peek()] }
 
   const fpq = new FastPriorityQueue(this.compare);

--- a/unit/basictests.js
+++ b/unit/basictests.js
@@ -341,4 +341,18 @@ describe('FastPriorityQueue', function() {
       if (x.poll() != item) throw 'bug';
     }
   });
+
+  it('should return k smallest with large k', function() {
+    // ascending
+    var x = new FastPriorityQueue(function(a, b) {
+      return a < b;
+    });
+    const largeK = 64;
+    const items = Array.from({ length: largeK }, (_, k) => k);
+    items.forEach((item) => x.add(item));
+
+    items.forEach((_,i) => {
+      if (JSON.stringify(x.kSmallest(i + 1)) !== JSON.stringify(items.slice(0, i+1))) throw 'bug';
+    });
+  });
 });


### PR DESCRIPTION
This fixes a bug where the calculation for the cloned tree depth in `kSmallest` could overflow, which caused a truncation of the tree. This would start filling the resulting array with incorrect values once at least a number of results was pulled about equal to the tree depth. The remainder of the array would be filled with with `undefined` values.

This still appears to offer a modest performance improvement over the code in `0.7.2` while avoiding the bug that was introduced in `0.7.3`. I settled on this implementation after experimenting with the following.
- Hybrid bit shifting (`<<`) and exponentiation (both `Math.pow` and `**`) split at ~31 bits
- `BigInt` conversion
- String-based bit shifting
- More conditional logic
- Looping w/ multiplication